### PR TITLE
Use dockerized version of Plantuml

### DIFF
--- a/doc/img/Makefile
+++ b/doc/img/Makefile
@@ -1,4 +1,14 @@
-PLANTUML := plantuml
+DOCKER := $(shell command -v docker 2> /dev/null)
+PODMAN := $(shell command -v podman 2> /dev/null)
+
+PLANTUML_IMAGE := fhofherr/plantuml:1.2019.11
+ifdef PODMAN
+	PLANTUML := $(PODMAN) run --rm -i $(PLANTUML_IMAGE) -pipe
+else ifdef DOCKER
+	PLANTUML := $(DOCKER) run --rm -i $(PLANTUML_IMAGE) -pipe
+else
+	$(error "Neither podman nor docker found.")
+endif
 
 SRC_FILES := $(wildcard *.puml)
 SVG_FILES := $(patsubst %.puml,%.svg,$(SRC_FILES))
@@ -7,10 +17,10 @@ PNG_FILES := $(patsubst %.puml,%.png,$(SRC_FILES))
 .DEFAULT_GOAL := svg
 
 %.svg: %.puml
-	$(PLANTUML) -tsvg $<
+	cat $< | $(PLANTUML) -tsvg > $@
 
 %.png: %.puml
-	$(PLANTUML) -tpng $<
+	cat $< | $(PLANTUML) -tpng  > $@
 
 .PHONY: svg
 svg: $(SVG_FILES)


### PR DESCRIPTION
This allows to build the documentation diagrams without actually needing
to install Java and Plantuml.